### PR TITLE
createAccount

### DIFF
--- a/templates/CCBuiltIn.yaml
+++ b/templates/CCBuiltIn.yaml
@@ -19,7 +19,6 @@ Parameters:
   pEnvironment:
     Type: String
     Description: CloudCheckr Environment(US, EU, AU, GOV)
-    NoEcho: true
   pCustomerNumber:
     AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$
     Type: String


### PR DESCRIPTION
reconfigured code to always first check for the existing account ID in cloudcheckr before attempting to create the account.  This was backwards on the initial configuration.